### PR TITLE
ci: Limit release workflow triggers to specific paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release
 on:
   push:
     branches: [main, master]
+    paths:
+      - "src/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
+      - ".cargo/**"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Restrict workflow to specific paths for release triggers.